### PR TITLE
fixed check for security groups

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -33,7 +33,7 @@ resource aws_lambda_function lambda {
 
   // Only create vpc_config block if var.security_group_ids has a value
   dynamic "vpc_config" {
-    for_each = var.security_group_ids[0] == "" ? [] : [1]
+    for_each = length(var.security_group_ids) == 0 ? [] : [1]
     content {
       security_group_ids = var.security_group_ids
       subnet_ids         = var.subnet_ids


### PR DESCRIPTION
Fix for this issue that occurs when security_group_ids are not passed into the module.

![image](https://user-images.githubusercontent.com/2174370/122767248-72418a00-d270-11eb-8223-a56d41b18c66.png)
